### PR TITLE
fix: markdownセクションにインデントがかかっていると、エラーになってしまう

### DIFF
--- a/bin/validator.js
+++ b/bin/validator.js
@@ -98,12 +98,12 @@ async function validateMermaidCode(code) {
 
 export async function validateFile(filePath) {
   const content = await fs.readFile(filePath, 'utf-8');
-  const mermaidRegex = /```mermaid\n(.*?)\n```/gs;
+  const mermaidRegex = /^([ \t]*)```mermaid\n([\s\S]*?)\n\1```/gm;
   let match;
   const errors = [];
 
   while ((match = mermaidRegex.exec(content)) !== null) {
-    const mermaidCode = match[1];
+    const mermaidCode = match[2];
     const lineNumber = content.substring(0, match.index).split('\n').length;
 
     const result = await validateMermaidCode(mermaidCode);

--- a/test/fixtures/edge-cases/indented-blocks.md
+++ b/test/fixtures/edge-cases/indented-blocks.md
@@ -1,0 +1,114 @@
+# Indented Mermaid Blocks Test
+
+This document tests various indentation scenarios for Mermaid blocks.
+
+## 1. No Indentation (Standard)
+
+```mermaid
+graph TD
+    A[Start] --> B[Process]
+    B --> C[End]
+```
+
+## 2. Two Space Indentation
+
+  ```mermaid
+  graph TD
+      A[Start] --> B[Process]
+      B --> C[End]
+  ```
+
+## 3. Four Space Indentation
+
+    ```mermaid
+    graph TD
+        A[Start] --> B[Process]
+        B --> C[End]
+    ```
+
+## 4. Tab Indentation
+
+	```mermaid
+	graph TD
+	    A[Start] --> B[Process]
+	    B --> C[End]
+	```
+
+## 5. List Context
+
+### Unordered List
+
+- Item 1
+  ```mermaid
+  graph TD
+      A[Item1] --> B[SubItem]
+  ```
+
+- Item 2
+    ```mermaid
+    graph TD
+        A[Item2] --> B[SubItem]
+    ```
+
+### Ordered List
+
+1. First item
+   ```mermaid
+   graph TD
+       A[First] --> B[Action]
+   ```
+
+2. Second item
+     ```mermaid
+     graph TD
+         A[Second] --> B[Action]
+     ```
+
+## 6. Nested Structure
+
+> Blockquote with mermaid
+> 
+> ```mermaid
+> graph TD
+>     A[Quote] --> B[Content]
+> ```
+
+## 7. Complex Diagram with Indentation
+
+  ```mermaid
+  sequenceDiagram
+      participant Alice
+      participant Bob
+      Alice->>John: Hello John, how are you?
+      loop Healthcheck
+          John->>John: Fight against hypochondria
+      end
+      Note right of John: Rational thoughts <br/>prevail!
+      John-->>Alice: Great!
+      John->>Bob: How about you?
+      Bob-->>John: Jolly good!
+  ```
+
+## 8. Invalid Syntax with Indentation
+
+  ```mermaid
+  graph TD
+      A[Start] -->
+  ```
+
+## 9. Mixed Valid and Invalid
+
+```mermaid
+graph TD
+    A[Valid] --> B[Diagram]
+```
+
+  ```mermaid
+  graph TD
+      C[Invalid -->
+  ```
+
+    ```mermaid
+    graph TD
+        D[Valid] --> E[Again]
+    ```


### PR DESCRIPTION
### issue

- https://github.com/suwa-sh/md-mermaid-lint/issues/2
