### PR TITLE
fix(deps): build(deps): bump node from 20-slim to 26-slim (replaces #13)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Node.js slim image for smaller size
-FROM node:20-slim
+FROM node:26-slim
 
 # Install Chromium and its dependencies for Puppeteer
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node:26-slim
 # Install Chromium and its dependencies for Puppeteer
 RUN apt-get update && apt-get install -y \
     chromium \
-    fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
+    fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-freefont-ttf \
     libxss1 \
     --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Replaces #13 (CI broken). Includes the dependabot bump and the fix needed for it to pass CI.